### PR TITLE
fix: use release mode for Windows tests to avoid LNK1318 PDB error

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -7,12 +7,14 @@ on:
       - 'src/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - '.github/workflows/cross-platform.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'src/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - '.github/workflows/cross-platform.yml'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -116,6 +116,8 @@ jobs:
         run: |
           if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
             cargo test --all-targets --all-features --quiet -- --test-threads=1
+          elif [ "${{ matrix.os }}" == "windows-latest" ]; then
+            cargo test --all-targets --release --quiet
           else
             cargo test --all-targets --quiet
           fi
@@ -135,6 +137,8 @@ jobs:
         run: |
           if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
             cargo test health --all-features --quiet
+          elif [ "${{ matrix.os }}" == "windows-latest" ]; then
+            cargo test health --release --quiet
           else
             cargo test health --quiet
           fi


### PR DESCRIPTION
## Summary
Fixes Windows CI linker error LNK1318 (PDB size limit exceeded) by using release mode for Windows tests.

## Changes
- Windows tests now run with `--release` flag
- Produces smaller binaries without debug info
- Avoids PDB file size limit (known Microsoft linker limitation)

## Benefits
- ✅ Faster test execution on Windows
- ✅ Smaller artifact sizes
- ✅ Eliminates transient LNK1318 errors
- ✅ Maintains full test coverage

Closes the Windows linker issue identified in #18.