### PR TITLE
fix: use cross-platform temp directory for SQLite tests

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main", "debug/*", "feature/*" ]
     paths:
       - 'src/**'
+      - 'tests/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/cross-platform.yml'
@@ -12,6 +13,7 @@ on:
     branches: [ main ]
     paths:
       - 'src/**'
+      - 'tests/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/cross-platform.yml'

--- a/tests/database_plugins_test.rs
+++ b/tests/database_plugins_test.rs
@@ -11,7 +11,9 @@ async fn create_test_database() -> Database {
     let encryption_key = (0..32).collect::<Vec<u8>>();
     // Use a unique database file path for each test to ensure isolation
     let unique_id = uuid::Uuid::new_v4();
-    let database_url = format!("sqlite:/tmp/test_{unique_id}.db");
+    let temp_dir = std::env::temp_dir();
+    let db_path = temp_dir.join(format!("test_{unique_id}.db"));
+    let database_url = format!("sqlite:{}", db_path.display());
     Database::new(&database_url, encryption_key)
         .await
         .expect("Failed to create test database")


### PR DESCRIPTION
## Summary
Fixes Windows SQLite test failures by using cross-platform temp directory.

## Problem
Tests were hardcoded to use `/tmp/` which doesn't exist on Windows, causing:
```
error returned from database: (code: 14) unable to open database file
```

## Solution
- Use `std::env::temp_dir()` instead of hardcoded `/tmp/`
- Works on all platforms (Linux, macOS, Windows)

## Testing
- Tests now pass on Windows
- No impact on Linux/macOS (same behavior)